### PR TITLE
Refactor visualiser and introduce maze controller

### DIFF
--- a/Main.tscn
+++ b/Main.tscn
@@ -4,10 +4,12 @@
 [ext_resource type="PackedScene" uid="uid://b56xordbbvcq0" path="res://MazeGenerator/MazeVisualiser.tscn" id="2_r0du0"]
 [ext_resource type="PackedScene" uid="uid://bibxrhj7eydpo" path="res://MazeGenerator/MazeGenerator.tscn" id="3_cm0pq"]
 
-[node name="Main" type="Node2D"]
+[node name="Main" type="Node2D" node_paths=PackedStringArray("generator", "visualiser")]
 script = ExtResource("1_glv2v")
 generator = NodePath("MazeGenerator")
 visualiser = NodePath("MazeVisualiser")
+base_illuminated_radius = 2
+matchstick_hold_time = 1.0
 
 [node name="MazeVisualiser" parent="." node_paths=PackedStringArray("controller") instance=ExtResource("2_r0du0")]
 position = Vector2(555, 334)

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,21 +1,19 @@
 [gd_scene load_steps=4 format=3 uid="uid://dv17qr5akn2xf"]
 
-[ext_resource type="Script" uid="uid://dypmn3chqtjv0" path="res://MazeGenerator/maze_generator.gd" id="1_glv2v"]
+[ext_resource type="Script" uid="uid://c0b70vaq8ime7" path="res://main.gd" id="1_glv2v"]
 [ext_resource type="PackedScene" uid="uid://b56xordbbvcq0" path="res://MazeGenerator/MazeVisualiser.tscn" id="2_r0du0"]
 [ext_resource type="PackedScene" uid="uid://bibxrhj7eydpo" path="res://MazeGenerator/MazeGenerator.tscn" id="3_cm0pq"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_glv2v")
+generator = NodePath("MazeGenerator")
+visualiser = NodePath("MazeVisualiser")
 
-[node name="MazeVisualiser" parent="." node_paths=PackedStringArray("generator") instance=ExtResource("2_r0du0")]
+[node name="MazeVisualiser" parent="." node_paths=PackedStringArray("controller") instance=ExtResource("2_r0du0")]
 position = Vector2(555, 334)
 cell_size = 32
-generator = NodePath("../MazeGenerator")
+controller = NodePath("..")
 dim_alpha = 0.0
-base_illuminated_radius = 2
-matchstick_radius = 8
-matchstick_fade_down_time = 1.5
-matchstick_hold_time = 1.0
 
 [node name="MazeGenerator" parent="." instance=ExtResource("3_cm0pq")]
 position = Vector2(1, 2)

--- a/MazeGenerator/maze_visualiser.gd
+++ b/MazeGenerator/maze_visualiser.gd
@@ -1,107 +1,37 @@
 extends Node2D
 
+## Draws the maze based on the state provided by a controller node.
+
 @export var cell_size: int = 48
-@export var generator: MazeGenerator
+@export var controller: Node
 @export var fully_lit_alpha: float = 1.0
 @export var dim_alpha: float = 0.1
-@export var base_illuminated_radius: int = 1
-@export var matchstick_radius: int = 5
-@export var matchstick_fade_up_time: float = 0.05
-@export var matchstick_fade_down_time: float = 0.5 # seconds
-@export var matchstick_hold_time: float = 3.0 # seconds to wait at max brightness before fading down
-
-
-var maze: Dictionary[Vector2i, MazeGenerator.RoomData] = {}
-var player_pos: Vector2i = Vector2i.ZERO
-var illuminated_radius: float = 1.0 # Use float for tweening
-var _matchstick_active := false
 
 func _ready() -> void:
-    illuminated_radius = float(base_illuminated_radius)
-    if generator == null:
-        push_error("MazeVisualizer: No MazeGenerator assigned.")
-    else:
-        _generate_and_draw_maze()
-
-func _generate_and_draw_maze() -> void:
-    if generator == null:
-        push_error("MazeVisualizer: No MazeGenerator assigned.")
-        return
-    maze = generator.generate_maze()
-    print("Maze generated with ", maze.size(), " rooms (room_count=", generator.room_count, ", branch_chance=", generator.branch_chance, ", max_walkers=", generator.max_walkers, ")")
-    queue_redraw()
-
-func _unhandled_input(event):
-    if event.is_action_pressed("ui_accept"): # Or any action you like
-        use_matchstick()
-
-func get_maze_distances(from: Vector2i) -> Dictionary[Vector2i, int]:
-    var distances: Dictionary[Vector2i, int] = {}
-    var queue: Array[Vector2i] = [from]
-    distances[from] = 0
-    while queue.size() > 0:
-        var current = queue.pop_front()
-        var current_dist = distances[current]
-        for dir in MazeGenerator.DIRECTIONS:
-            var neighbor = current + dir
-            if maze.has(neighbor) and not distances.has(neighbor):
-                distances[neighbor] = current_dist + 1
-                queue.append(neighbor)
-    return distances
+    if controller == null:
+        push_error("MazeVisualiser: No controller assigned.")
 
 func _draw() -> void:
-    if maze.is_empty():
-        push_warning("MazeVisualizer: Maze is empty, call _generate_and_draw_maze() first.")
+    if controller == null:
         return
-    print("Drawing maze with ", maze.size(), " rooms")
-    var distances = get_maze_distances(player_pos)
+    var maze: Dictionary = controller.maze
+    if maze.is_empty():
+        return
+    var distances = controller.get_maze_distances(controller.player_pos)
     for pos in maze.keys():
         var room = maze[pos]
         var dist = distances.get(pos, null)
         var alpha := dim_alpha
-        if dist == null or dist > int(illuminated_radius):
-            alpha = dim_alpha
-        else:
-            var t := float(dist) / illuminated_radius
+        if dist != null and dist <= int(controller.illuminated_radius):
+            var t := float(dist) / controller.illuminated_radius
             alpha = lerp(fully_lit_alpha, dim_alpha, t)
-        var base_color = _get_room_color(room.type)
+        var base_color = _get_room_color(room.type, controller.is_matchstick_active())
         var color = Color(base_color.r, base_color.g, base_color.b, alpha)
         draw_rect(Rect2(pos * cell_size, Vector2(cell_size, cell_size)), color)
         draw_rect(Rect2(pos * cell_size, Vector2(cell_size, cell_size)), Color(0,0,0,alpha), false, 2.0)
-    # Player marker:
-    draw_rect(Rect2(player_pos * cell_size, Vector2(cell_size, cell_size)), Color(1, 1, 0, 1.0), false, 4.0)
-    # Player marker
-    draw_rect(Rect2(player_pos * cell_size, Vector2(cell_size, cell_size)), Color(1, 1, 0, 1.0), false, 4.0)
+    draw_rect(Rect2(controller.player_pos * cell_size, Vector2(cell_size, cell_size)), Color(1, 1, 0, 1.0), false, 4.0)
 
-func use_matchstick():
-    if _matchstick_active:
-        return
-    _matchstick_active = true
-    await _burst_and_fade_matchstick()
-
-func _burst_and_fade_matchstick() -> void:
-    # Fade up to matchstick brightness
-    await _tween_radius(float(illuminated_radius), float(matchstick_radius), matchstick_fade_up_time)
-    # Hold at max brightness
-    if matchstick_hold_time > 0.0:
-        await get_tree().create_timer(matchstick_hold_time).timeout
-    # Fade down to base
-    await _tween_radius(float(matchstick_radius), float(base_illuminated_radius), matchstick_fade_down_time)
-    illuminated_radius = float(base_illuminated_radius)
-    _matchstick_active = false
-    queue_redraw()
-
-func _tween_radius(from: float, to: float, duration: float) -> void:
-    var t := 0.0
-    while t < duration:
-        await get_tree().process_frame
-        t += get_process_delta_time()
-        var ratio: float = clamp(t / duration, 0, 1)
-        illuminated_radius = lerp(from, to, ratio)
-        queue_redraw()
-
-
-func _get_room_color(room_type: MazeGenerator.RoomType) -> Color:
+func _get_room_color(room_type: MazeGenerator.RoomType, matchstick_active: bool) -> Color:
     var color: Color
     match room_type:
         MazeGenerator.RoomType.START:
@@ -119,11 +49,13 @@ func _get_room_color(room_type: MazeGenerator.RoomType) -> Color:
         _:
             color = Color.GRAY
     # if matchstick is active, use a yellow tint
-    if _matchstick_active:
+    if matchstick_active:
         color = color.lerp(Color.YELLOW, 0.5)
     return color
 
-# Call this function (from an EditorPlugin or a custom UI button) to regenerate the maze after you tweak the generator's properties.
+# Call this function (from an EditorPlugin or a custom UI button) to regenerate the maze.
 func regenerate() -> void:
-    _generate_and_draw_maze()
+    if controller:
+        controller.generate_maze()
+        queue_redraw()
 

--- a/MazeGenerator/maze_visualiser.gd
+++ b/MazeGenerator/maze_visualiser.gd
@@ -23,7 +23,7 @@ func _draw() -> void:
         var dist = distances.get(pos, null)
         var alpha := dim_alpha
         if dist != null and dist <= int(controller.illuminated_radius):
-            var t := float(dist) / controller.illuminated_radius
+            var t: float = float(dist) / controller.illuminated_radius
             alpha = lerp(fully_lit_alpha, dim_alpha, t)
         var base_color = _get_room_color(room.type, controller.is_matchstick_active())
         var color = Color(base_color.r, base_color.g, base_color.b, alpha)
@@ -58,4 +58,3 @@ func regenerate() -> void:
     if controller:
         controller.generate_maze()
         queue_redraw()
-

--- a/main.gd
+++ b/main.gd
@@ -1,1 +1,78 @@
 extends Node2D
+class_name MazeGame
+
+@export var generator: MazeGenerator
+@export var visualiser: Node2D
+@export var base_illuminated_radius: int = 1
+@export var matchstick_radius: int = 5
+@export var matchstick_fade_up_time: float = 0.05
+@export var matchstick_fade_down_time: float = 0.5 # seconds
+@export var matchstick_hold_time: float = 3.0 # seconds at max brightness
+
+var maze: Dictionary[Vector2i, MazeGenerator.RoomData] = {}
+var player_pos: Vector2i = Vector2i.ZERO
+var illuminated_radius: float = 1.0
+var _matchstick_active := false
+
+func _ready() -> void:
+    illuminated_radius = float(base_illuminated_radius)
+    if generator == null:
+        push_error("MazeGame: No MazeGenerator assigned.")
+    else:
+        generate_maze()
+
+func _unhandled_input(event) -> void:
+    if event.is_action_pressed("ui_accept"):
+        use_matchstick()
+
+func generate_maze() -> void:
+    if generator == null:
+        push_error("MazeGame: No MazeGenerator assigned.")
+        return
+    maze = generator.generate_maze()
+    player_pos = Vector2i.ZERO
+    if visualiser:
+        visualiser.queue_redraw()
+
+func get_maze_distances(from: Vector2i) -> Dictionary[Vector2i, int]:
+    var distances: Dictionary[Vector2i, int] = {}
+    var queue: Array[Vector2i] = [from]
+    distances[from] = 0
+    while queue.size() > 0:
+        var current = queue.pop_front()
+        var current_dist = distances[current]
+        for dir in MazeGenerator.DIRECTIONS:
+            var neighbor = current + dir
+            if maze.has(neighbor) and not distances.has(neighbor):
+                distances[neighbor] = current_dist + 1
+                queue.append(neighbor)
+    return distances
+
+func use_matchstick() -> void:
+    if _matchstick_active:
+        return
+    _matchstick_active = true
+    await _burst_and_fade_matchstick()
+
+func _burst_and_fade_matchstick() -> void:
+    await _tween_radius(float(illuminated_radius), float(matchstick_radius), matchstick_fade_up_time)
+    if matchstick_hold_time > 0.0:
+        await get_tree().create_timer(matchstick_hold_time).timeout
+    await _tween_radius(float(matchstick_radius), float(base_illuminated_radius), matchstick_fade_down_time)
+    illuminated_radius = float(base_illuminated_radius)
+    _matchstick_active = false
+    if visualiser:
+        visualiser.queue_redraw()
+
+func _tween_radius(from: float, to: float, duration: float) -> void:
+    var t := 0.0
+    while t < duration:
+        await get_tree().process_frame
+        t += get_process_delta_time()
+        var ratio: float = clamp(t / duration, 0, 1)
+        illuminated_radius = lerp(from, to, ratio)
+        if visualiser:
+            visualiser.queue_redraw()
+
+func is_matchstick_active() -> bool:
+    return _matchstick_active


### PR DESCRIPTION
## Summary
- create a `MazeGame` controller script to manage the maze state
- simplify `MazeVisualiser` so it only draws based on the controller
- update `Main.tscn` to wire the new controller and visualiser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846af6cb69c832e9f9e94c6b83ab892