### PR TITLE
Add script for running all Godot tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Godot 4+ specific ignores
 .godot/
 /android/
+Godot_v4.4.1-stable_linux.x86_64
+Godot_v4.4.1-stable_linux.x86_64.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# Agent Instructions
+
+## Test Environment Setup
+- Download the Godot 4.4.1 executable to run tests.
+- Example commands for Linux x86_64:
+
+```bash
+curl -L -o Godot_v4.4.1-stable_linux.x86_64.zip \
+  https://downloads.tuxfamily.org/godotengine/4.4.1/Godot_v4.4.1-stable_linux.x86_64.zip
+unzip Godot_v4.4.1-stable_linux.x86_64.zip
+chmod +x Godot_v4.4.1-stable_linux.x86_64
+```
+
+The executable must be available in the repository root when running tests.
+
+## Running Tests
+- Run the following commands from the repository root:
+
+```bash
+./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s res://tests/test_addition.gd
+./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s res://tests/test_maze_data.gd
+```
+Alternatively, execute all test scripts using `tests/run_all_tests.sh`:
+
+```bash
+./tests/run_all_tests.sh
+```
+
+Make sure the commands exit with status code `0` to pass tests.
+
+## Additional Notes
+- Keep the Godot binary out of version control. Download it in each new environment when needed.
+- Use the exact test file paths provided above.

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+GODOT_BIN="./Godot_v4.4.1-stable_linux.x86_64"
+for test_script in tests/*.gd; do
+    "$GODOT_BIN" --headless --path . -s "$test_script"
+done


### PR DESCRIPTION
## Summary
- add ignore entries for downloaded Godot binary
- document using run_all_tests.sh in AGENTS.md
- add tests/run_all_tests.sh for convenience

## Testing
- `./tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684773d5b020832eb4a51ffabf208508