### PR TITLE
Add maze generator tests

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -49,7 +49,7 @@ func generate_maze() -> void:
     if generator == null or maze_data == null:
         push_error("MazeGame: No MazeGenerator or MazeData assigned.")
         return
-    generator.generate_maze(start_pos)
+    generator.generate_maze(maze_data, start_pos)
     if player:
         player.position = start_pos
     if visualiser:

--- a/tests/test_maze_generator.gd
+++ b/tests/test_maze_generator.gd
@@ -1,0 +1,38 @@
+extends SceneTree
+
+func _init():
+    var MazeGenerator := preload("res://MazeGenerator/maze_generator.gd")
+    var MazeData := preload("res://MazeGenerator/MazeData.gd")
+
+    # Use a fixed random seed for deterministic output
+    seed(1)
+
+    var gen = MazeGenerator.new()
+    get_root().add_child(gen)
+    await gen.ready
+
+    var data = MazeData.new()
+    gen.room_count = 10
+    gen.bounds_min = Vector2i(-5, -5)
+    gen.bounds_max = Vector2i(5, 5)
+    gen.generate_maze(data, Vector2i.ZERO)
+
+    if data.maze.size() > gen.room_count + 1:
+        push_error("Maze has more rooms than expected")
+        quit(1)
+
+    var exit_pos
+    for pos in data.maze.keys():
+        if data.maze[pos] == gen.room_exit:
+            exit_pos = pos
+            break
+
+    if exit_pos == null:
+        push_error("Maze has no exit room")
+        quit(1)
+    elif exit_pos == Vector2i.ZERO:
+        push_error("Exit room cannot be at the start position")
+        quit(1)
+
+    print("MazeGenerator test passed")
+    quit()


### PR DESCRIPTION
## Summary
- refactor `MazeGenerator` to work directly with a `MazeData` instance
- update `MazeGame` to pass its `MazeData` to the generator
- add a new GDScript unit test for `MazeGenerator`
- ensure the generator handles empty `room_types` gracefully
- fix the test to wait for the generator's `ready` signal and adjust room count check

## Testing
- `./tests/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684777ae6104832e926b993ccb040ef3