### PR TITLE
Refactor main into subcomponents

### DIFF
--- a/Game/input_handler.gd
+++ b/Game/input_handler.gd
@@ -1,0 +1,26 @@
+extends Node
+
+class_name InputHandler
+
+@export var player: Player
+@export var game: MazeGame
+@export var matchstick_manager: Node
+
+func _unhandled_input(event) -> void:
+    var moved := false
+    if event.is_action_pressed("move_left"):
+        player.try_move(Vector2i.LEFT, game)
+        moved = true
+    elif event.is_action_pressed("move_right"):
+        player.try_move(Vector2i.RIGHT, game)
+        moved = true
+    elif event.is_action_pressed("move_up"):
+        player.try_move(Vector2i.UP, game)
+        moved = true
+    elif event.is_action_pressed("move_down"):
+        player.try_move(Vector2i.DOWN, game)
+        moved = true
+    elif event.is_action_pressed("ui_accept"):
+        matchstick_manager.use_matchstick()
+    # Visual updates happen via signals
+

--- a/Game/input_handler.gd.uid
+++ b/Game/input_handler.gd.uid
@@ -1,0 +1,1 @@
+uid://cqunvoqonjcng

--- a/Game/matchstick_manager.gd
+++ b/Game/matchstick_manager.gd
@@ -1,0 +1,68 @@
+extends Node
+
+class_name MatchstickManager
+
+signal illumination_changed
+
+@export var player: Player
+@export var matchstick_radius: int = 8
+@export var matchstick_fade_up_time: float = 0.1
+@export var matchstick_fade_down_time: float = 1.5
+@export var matchstick_hold_time: float = 2.0
+
+var matchsticks: Array[Matchstick] = []
+
+func use_matchstick() -> void:
+    if player == null:
+        return
+    var matchstick = Matchstick.new()
+    add_child(matchstick)
+    matchstick.configure(
+        player.vision_radius,
+        matchstick_radius,
+        matchstick_fade_up_time,
+        matchstick_fade_down_time,
+        matchstick_hold_time
+    )
+    matchstick.illumination_changed.connect(_on_matchstick_changed)
+    matchstick.matchstick_out.connect(_on_matchstick_out.bind(matchstick))
+    matchstick.use(player.position)
+    matchsticks.append(matchstick)
+    illumination_changed.emit()
+
+func _on_matchstick_changed() -> void:
+    illumination_changed.emit()
+
+func _on_matchstick_out(matchstick: Matchstick) -> void:
+    if matchsticks.has(matchstick):
+        matchsticks.erase(matchstick)
+        matchstick.queue_free()
+        illumination_changed.emit()
+
+func is_matchstick_active() -> bool:
+    for m in matchsticks:
+        if m.is_active():
+            return true
+    return false
+
+func get_illumination_origin(default_origin: Vector2i) -> Vector2i:
+    var reversed_matchsticks = matchsticks.duplicate()
+    reversed_matchsticks.reverse()
+    for m in reversed_matchsticks:
+        if m.is_active():
+            return m.get_origin(default_origin)
+    return default_origin
+
+func get_illuminated_radius() -> float:
+    var reversed_matchsticks = matchsticks.duplicate()
+    reversed_matchsticks.reverse()
+    for m in reversed_matchsticks:
+        if m.is_active():
+            return m.get_radius()
+    return 0.0
+
+func clear_matchsticks() -> void:
+    for m in matchsticks:
+        m.queue_free()
+    matchsticks.clear()
+

--- a/Game/matchstick_manager.gd.uid
+++ b/Game/matchstick_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://bqcvykf6b4wec

--- a/Main.tscn
+++ b/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=10 format=3 uid="uid://dv17qr5akn2xf"]
+[gd_scene load_steps=12 format=3 uid="uid://dv17qr5akn2xf"]
 
 [ext_resource type="Script" uid="uid://c0b70vaq8ime7" path="res://main.gd" id="1_glv2v"]
 [ext_resource type="PackedScene" uid="uid://b56xordbbvcq0" path="res://MazeGenerator/MazeVisualiser.tscn" id="2_r0du0"]
@@ -9,8 +9,8 @@
 [ext_resource type="Resource" uid="uid://c0d1q2c4uqejf" path="res://Enemies/Slime/slime_enemy.tres" id="6_slime"]
 [ext_resource type="Script" path="res://Entities/Enemy.gd" id="6_wkp8b"]
 [ext_resource type="Script" uid="uid://bx85nu0nabb6q" path="res://camera_2d.gd" id="7_lgr22"]
-[ext_resource type="Script" path="res://Game/input_handler.gd" id="8_input"]
-[ext_resource type="Script" path="res://Game/matchstick_manager.gd" id="9_match"]
+[ext_resource type="Script" uid="uid://cqunvoqonjcng" path="res://Game/input_handler.gd" id="8_input"]
+[ext_resource type="Script" uid="uid://bqcvykf6b4wec" path="res://Game/matchstick_manager.gd" id="9_match"]
 
 [node name="Main" type="Node2D" node_paths=PackedStringArray("generator", "visualiser", "player", "input_handler", "matchstick_manager")]
 script = ExtResource("1_glv2v")
@@ -44,8 +44,12 @@ position = Vector2(2, 0)
 anchor_mode = 0
 script = ExtResource("7_lgr22")
 
-[node name="InputHandler" type="Node" parent="."]
+[node name="InputHandler" type="Node" parent="." node_paths=PackedStringArray("player", "game", "matchstick_manager")]
 script = ExtResource("8_input")
+player = NodePath("../Player")
+game = NodePath("..")
+matchstick_manager = NodePath("../MatchstickManager")
 
-[node name="MatchstickManager" type="Node" parent="."]
+[node name="MatchstickManager" type="Node" parent="." node_paths=PackedStringArray("player")]
 script = ExtResource("9_match")
+player = NodePath("../Player")

--- a/Main.tscn
+++ b/Main.tscn
@@ -9,13 +9,16 @@
 [ext_resource type="Resource" uid="uid://c0d1q2c4uqejf" path="res://Enemies/Slime/slime_enemy.tres" id="6_slime"]
 [ext_resource type="Script" path="res://Entities/Enemy.gd" id="6_wkp8b"]
 [ext_resource type="Script" uid="uid://bx85nu0nabb6q" path="res://camera_2d.gd" id="7_lgr22"]
+[ext_resource type="Script" path="res://Game/input_handler.gd" id="8_input"]
+[ext_resource type="Script" path="res://Game/matchstick_manager.gd" id="9_match"]
 
-[node name="Main" type="Node2D" node_paths=PackedStringArray("generator", "visualiser", "player")]
+[node name="Main" type="Node2D" node_paths=PackedStringArray("generator", "visualiser", "player", "input_handler", "matchstick_manager")]
 script = ExtResource("1_glv2v")
 generator = NodePath("MazeGenerator")
 visualiser = NodePath("MazeVisualiser")
-matchstick_hold_time = 1.0
 player = NodePath("Player")
+input_handler = NodePath("InputHandler")
+matchstick_manager = NodePath("MatchstickManager")
 
 [node name="MazeVisualiser" parent="." node_paths=PackedStringArray("controller") instance=ExtResource("2_r0du0")]
 position = Vector2(576, 320)
@@ -40,3 +43,9 @@ enemy_types = Array[ExtResource("6_wkp8b")]([ExtResource("6_slime")])
 position = Vector2(2, 0)
 anchor_mode = 0
 script = ExtResource("7_lgr22")
+
+[node name="InputHandler" type="Node" parent="."]
+script = ExtResource("8_input")
+
+[node name="MatchstickManager" type="Node" parent="."]
+script = ExtResource("9_match")

--- a/MazeGenerator/maze_visualiser.gd
+++ b/MazeGenerator/maze_visualiser.gd
@@ -20,7 +20,7 @@ func _draw() -> void:
 
     var player = controller.player
     var player_origin = player.position
-    var matchsticks = controller.matchsticks
+    var matchsticks = controller.matchstick_manager.matchsticks
     var matchstick_data = []
     for m in matchsticks:
         if m.is_active():

--- a/main.gd
+++ b/main.gd
@@ -20,13 +20,17 @@ func _ready() -> void:
     input_handler.player = player
     input_handler.game = self
     input_handler.matchstick_manager = matchstick_manager
-    generator.maze_generated.connect(visualiser.queue_redraw)
+    generator.maze_generated.connect(_on_maze_generated)
     if generator == null:
         push_error("MazeGame: No MazeGenerator assigned.")
     else:
         generate_maze()
 
 func _on_illumination_changed() -> void:
+    if visualiser:
+        visualiser.queue_redraw()
+
+func _on_maze_generated() -> void:
     if visualiser:
         visualiser.queue_redraw()
 

--- a/main.gd
+++ b/main.gd
@@ -5,20 +5,21 @@ class_name MazeGame
 
 @export var generator: MazeGenerator
 @export var visualiser: Node2D
-@export var matchstick_radius: int = 8
-@export var matchstick_fade_up_time: float = 0.1
-@export var matchstick_fade_down_time: float = 1.5 # seconds
-@export var matchstick_hold_time: float = 2.0 # seconds at max brightness
 @export var player: Player
+@export var input_handler: InputHandler
+@export var matchstick_manager: MatchstickManager
 
 var maze_data: MazeData
-var matchsticks: Array[Matchstick] = []
 
 func _ready() -> void:
     maze_data = MazeData.new()
     # No longer create a single matchstick here
     player.memory_updated.connect(_on_illumination_changed)
     player.position_changed.connect(_on_player_position_changed)
+    matchstick_manager.illumination_changed.connect(_on_illumination_changed)
+    input_handler.player = player
+    input_handler.game = self
+    input_handler.matchstick_manager = matchstick_manager
     generator.maze_generated.connect(visualiser.queue_redraw)
     if generator == null:
         push_error("MazeGame: No MazeGenerator assigned.")
@@ -32,28 +33,12 @@ func _on_illumination_changed() -> void:
 #update camera position
 func _on_player_position_changed(new_position: Vector2i) -> void:
     camera.update_camera_position(new_position)
-
-func _unhandled_input(event) -> void:
-    var moved := false
-    if event.is_action_pressed("move_left"):
-        player.try_move(Vector2i.LEFT, self)
-        moved = true
-    elif event.is_action_pressed("move_right"):
-        player.try_move(Vector2i.RIGHT, self)
-        moved = true
-    elif event.is_action_pressed("move_up"):
-        player.try_move(Vector2i.UP, self)
-        moved = true
-    elif event.is_action_pressed("move_down"):
-        player.try_move(Vector2i.DOWN, self)
-        moved = true
-    elif event.is_action_pressed("ui_accept"):
-        use_matchstick()
-    if moved and visualiser:
+    if visualiser:
         visualiser.queue_redraw()
 
+
 func generate_maze() -> void:
-    matchsticks.clear()
+    matchstick_manager.clear_matchsticks()
     if player:
         player.clear_memory()
 
@@ -74,48 +59,13 @@ func get_maze_distances(from: Vector2i) -> Dictionary[Vector2i, int]:
     return maze_data.get_distances(from)
 
 func use_matchstick() -> void:
-    var matchstick = Matchstick.new()
-    add_child(matchstick)
-    matchstick.configure(
-        player.vision_radius,
-        matchstick_radius,
-        matchstick_fade_up_time,
-        matchstick_fade_down_time,
-        matchstick_hold_time
-    )
-    matchstick.illumination_changed.connect(_on_illumination_changed)
-    matchstick.matchstick_out.connect(_on_matchstick_out.bind(matchstick))
-    matchstick.use(player.position)
-    matchsticks.append(matchstick)
-
-func _on_matchstick_out(matchstick: Matchstick) -> void:
-    if matchsticks.has(matchstick):
-        matchsticks.erase(matchstick)
-        matchstick.queue_free()
-        if visualiser:
-            visualiser.queue_redraw()
+    matchstick_manager.use_matchstick()
 
 func is_matchstick_active() -> bool:
-    # Returns true if any matchstick is active
-    for m in matchsticks:
-        if m.is_active():
-            return true
-    return false
+    return matchstick_manager.is_matchstick_active()
 
 func get_illumination_origin() -> Vector2i:
-    # Return the origin of the most recently placed active matchstick, or player position
-    var reversed_matchsticks = matchsticks.duplicate()
-    reversed_matchsticks.reverse()
-    for m in reversed_matchsticks:
-        if m.is_active():
-            return m.get_origin(player.position)
-    return player.position
+    return matchstick_manager.get_illumination_origin(player.position)
 
 func get_illuminated_radius() -> float:
-    # Return the radius of the most recently placed active matchstick, or 0
-    var reversed_matchsticks = matchsticks.duplicate()
-    reversed_matchsticks.reverse()
-    for m in reversed_matchsticks:
-        if m.is_active():
-            return m.get_radius()
-    return 0.0
+    return matchstick_manager.get_illuminated_radius()


### PR DESCRIPTION
## Summary
- split matchstick and input logic into new components
- connect new components from the main scene
- keep Main.gd focused on orchestration only

## Testing
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s res://tests/test_addition.gd`
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s res://tests/test_maze_data.gd`
- `./Godot_v4.4.1-stable_linux.x86_64 --headless --path . -s res://tests/test_maze_generator.gd`


------
https://chatgpt.com/codex/tasks/task_e_68490a4dbda0832e9b04291784a3263c